### PR TITLE
POL-2227/configure watches in publish

### DIFF
--- a/lib/metri_collect/application.rb
+++ b/lib/metri_collect/application.rb
@@ -107,9 +107,7 @@ module MetriCollect
         when String
           metrics[metric_or_id]
         else
-          metric = MetricDefinition.build_metric(metric_or_id)
-          metric.namespace = metric.namespace.split("/").insert(1, metric_prefix).join("/") if metric_prefix
-          metric
+          MetricDefinition.build_metric(metric_or_id, application: self, prefix: metric_prefix)
         end
       end
     end


### PR DESCRIPTION
ticket: https://careerarc.atlassian.net/browse/POL-2227

Extract watcher definitions from args passed to `MetriCollect.publish`, create new `Watch` object for each, have Application's watchers commence watching as part of publishing. 

changes: 
 - `MetricDefinition` now handles its own namespacing, including prefixing; prefix passed in from `Application`
 - `MetricDefinition.build_metric` receives an `application` from `Application#convert_to_metric`
 - add `MetricDefinition#watches` method to process `watches` passed in as part of `publish` hash: 
  - builds Watch object using `Watch.from_object`, merging `dimensions` and `namespace` from MetricDefinition to ensure alarms monitor the correct metric
  - calls `application.watchers <<` with each Watch object
 